### PR TITLE
Enhance terminal chat and Bluetooth functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,112 @@
-# local_chat
-🧩 Local Network Chat App A versatile local chat system that lets users communicate via:  
-
-💻 Terminal-based chat for PC/Linux/Mac users  
-
-📱 Web browser-based UI for phone users via local Wi-Fi/hotspot  
-
-🔵 Bluetooth peer-to-peer chat for nearby devices without internet 
-
 # Local Chat Application
 
-A versatile local network chat application that supports multiple communication methods:
-- Web interface
-- Terminal client
-- Bluetooth communication
+A versatile local network chat application that supports multiple communication methods, allowing users to communicate via a web interface, a terminal client, or direct Bluetooth connection.
 
 ## Features
 
-- Real-time messaging with WebSockets
-- Terminal-based client with commands
-- Direct device-to-device communication via Bluetooth
-- No internet required for local network operation
-
-## Installation
-Clone the repository:
-
-```git clone https://github.com/gaur-avvv/local_chat.git```
-
-```cd local_chat```
-
-Install dependencies:
-
-```pip install -r requirements.txt```
-
-## Usage
-
-### Web Server
-
-Start the web server with:
-
-```python server.py```
-
-Then open a browser and navigate to `http://localhost:5000`
-
-### Terminal Client
-
-Run the terminal client:
-
-`python client.py`
-
-### Bluetooth Server
-
-Start a Bluetooth server:
-
-`python blue_server.py`
-
-### Bluetooth Client
-
-Connect to a Bluetooth server:
-
-`python blue_client.py`
-
-
-
-## Commands
-
-Terminal and Bluetooth clients support these commands:
-- `/exit` - Exit the chat
-- `/whoami` - Display your username
-- `/clear` - Clear the screen
+-   **Multiple Communication Modes:**
+    -   Network chat (Wi-Fi/Ethernet): Supports a web-based UI accessible from any device on the local network (including phones) and a terminal-based client for PC/Mac/Linux users.
+    -   Bluetooth chat: Enables direct peer-to-peer communication between two nearby devices without needing a network infrastructure.
+-   **Real-time Messaging:** Leverages WebSockets for instant message delivery in network mode.
+-   **Terminal Client Commands:** Offers commands like `/exit`, `/whoami`, and `/clear` for an enhanced terminal chat experience.
+-   **No Internet Required:** Fully functional on a local network or via Bluetooth without an internet connection.
 
 ## Requirements
 
-- Python 3.6+
-- Flask and Flask-SocketIO
-- WebSocket client
-- PyBluez (for Bluetooth functionality)
+-   Python 3.6+
+-   Bluetooth adapter (for Bluetooth chat feature).
+-   All other Python package dependencies are listed in `requirements.txt`.
 
+## Installation
 
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/gaur-avvv/local_chat.git
+    ```
+2.  **Navigate to the project directory:**
+    ```bash
+    cd local_chat
+    ```
+3.  **Install dependencies:**
+    This will install all necessary Python packages, including Flask, Flask-SocketIO, PyBluez, etc.
+    ```bash
+    pip install -r requirements.txt
+    ```
+    *Note for Bluetooth on Linux:* You might need to install additional system packages like `python3-bluez` or `libbluetooth-dev` (e.g., `sudo apt-get install libbluetooth-dev`).
 
+## Usage
 
+This application offers two main modes of communication:
 
+### 1. Network Chat (Wi-Fi/Ethernet)
 
+This mode uses your local network (Wi-Fi or Ethernet) to connect clients to a central server.
+
+**A. Start the Server:**
+Run the server script. This will host both the web UI and the WebSocket server for terminal clients.
+```bash
+python server.py
+```
+The server will start on `0.0.0.0:5000`. It will also print instructions on how to find your machine's local IP address. You'll need to share this IP address with other users on your network who want to connect.
+
+**Finding Your Server's IP Address:**
+To allow other users on your local network to connect to the server, they need its IP address. The server script will display common commands to find it when it starts. Here's a summary:
+*   **Windows:** Open Command Prompt and type `ipconfig`. Look for the 'IPv4 Address'.
+*   **Linux:** Open a terminal and type `ip addr` or `hostname -I`.
+*   **macOS:** Open Terminal and type `ifconfig`. Look for the 'inet' address.
+
+**B. Connect with a Client:**
+
+Users have two options to connect:
+
+*   **Web Client:**
+    Open a web browser and navigate to `http://<server_ip>:5000` (replace `<server_ip>` with the actual IP address of the machine running `server.py`). This is suitable for all devices, including mobile phones.
+
+*   **Terminal Client:**
+    Run the terminal client script:
+    ```bash
+    python client.py
+    ```
+    The client will prompt you to enter the server's IP address. Enter the IP address of the machine where `server.py` is running.
+
+### 2. Bluetooth Chat
+
+This mode allows for direct peer-to-peer communication between two Bluetooth-enabled devices.
+
+**Requirements & Setup:**
+*   **PyBluez:** Ensure PyBluez is installed (it's in `requirements.txt`).
+*   **Bluetooth Enabled:** Make sure Bluetooth is enabled on both devices.
+*   **Device Pairing & Discoverability:** For best results, devices should be paired at the operating system level before attempting to connect via the application. Ensure your device is discoverable by other Bluetooth devices.
+
+**How to Run:**
+1.  **Start the Bluetooth Server:**
+    One user starts the Bluetooth server script:
+    ```bash
+    python blue_server.py
+    ```
+    The server will advertise the "BluetoothChatService" and wait for a connection, printing the RFCOMM channel it's using.
+
+2.  **Start the Bluetooth Client:**
+    The other user runs the Bluetooth client script:
+    ```bash
+    python blue_client.py
+    ```
+    The client will search for nearby Bluetooth devices, list them, and then attempt to find and connect to the "BluetoothChatService" on the selected device.
+
+**Important Notes for Bluetooth Chat:**
+*   **Two Users Only:** The current Bluetooth scripts are designed for a one-to-one chat session.
+*   **Reliability:** Bluetooth connectivity can vary based on OS, drivers, hardware, and distance. If you encounter issues:
+    *   Confirm devices are paired at the OS level.
+    *   Try restarting Bluetooth on both devices.
+    *   Ensure the server script is running and successfully advertised the service.
+    *   Check the console for any Bluetooth-related error messages on both client and server.
+
+## Commands
+
+The Terminal Client (for Network Chat) and the Bluetooth Client support the following commands:
+-   `/exit` - Quit the chat application.
+-   `/whoami` - Display your current username.
+-   `/clear` - Clear the terminal screen.
+
+---
+*This README provides an overview of the local_chat application, its features, and how to use them.*

--- a/blue_client.py
+++ b/blue_client.py
@@ -1,38 +1,72 @@
-import bluetooth
+import bluetooth # Keep for bluetooth.btcommon.BluetoothError
 from datetime import datetime
 import threading
-from .utils import discover_and_connect_bluetooth
+from blue_utils import discover_and_connect_bluetooth # Corrected import
+import sys # For sys.exit()
 
-nearby_devices = bluetooth.discover_devices(duration=8, lookup_names=True)
-print("Found devices:")
-for idx, device in enumerate(nearby_devices):
-    print(f"{idx + 1}: {device[1]} - {device[0]}")
+sock = discover_and_connect_bluetooth()
 
-choice = int(input("Select device to connect: ")) - 1
-addr = nearby_devices[choice][0]
-port = 1
+if sock is None:
+    print("Failed to connect to a Bluetooth device. Exiting.")
+    sys.exit(1)
 
-sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-sock.connect((addr, port))
 username = input("Enter your username: ")
-
-print("Connected. Type /exit to quit.")
+print("Connected. Type /exit to quit or /clear to clear screen.")
 
 def listen():
+    try:
+        while True:
+            data = sock.recv(1024)
+            if not data:
+                print("\nDisconnected from server.\n> ", end="")
+                break
+            print("\n" + data.decode() + "\n> ", end="")
+    except bluetooth.btcommon.BluetoothError as e:
+        print(f"\nBluetooth error during receive: {e}. Disconnected.\n> ", end="")
+    except Exception as e:
+        print(f"\nError during receive: {e}. Disconnected.\n> ", end="")
+    finally:
+        # Potentially signal main thread to exit or attempt reconnection
+        print("Listener thread finished.")
+
+
+listener_thread = threading.Thread(target=listen, daemon=True)
+listener_thread.start()
+
+try:
     while True:
-        data = sock.recv(1024)
-        if not data:
+        msg = input("> ")
+        if msg == "/exit":
             break
-        print("\n" + data.decode() + "\n> ", end="")
+        elif msg == "/whoami":
+            print(f"You are {username}")
+            continue
+        elif msg == "/clear":
+            # Basic clear, might not work on all terminals perfectly
+            print("\033c", end="")
+            continue
 
-threading.Thread(target=listen, daemon=True).start()
+        timestamp = datetime.now().strftime('%H:%M')
+        full_message = f"[{timestamp}] {username}: {msg}"
+        try:
+            sock.send(full_message.encode())
+        except bluetooth.btcommon.BluetoothError as e:
+            print(f"Bluetooth error during send: {e}. Message may not have been sent.")
+            # Decide if we should break or try to continue
+            # For now, let's assume the listener will catch disconnection
+            pass
+        except Exception as e:
+            print(f"Error during send: {e}. Message may not have been sent.")
+            pass
 
-while True:
-    msg = input("> ")
-    if msg == "/exit":
-        break
-    timestamp = datetime.now().strftime('%H:%M')
-    full_message = f"[{timestamp}] {username}: {msg}"
-    sock.send(full_message.encode())
-
-sock.close()
+except KeyboardInterrupt:
+    print("\nExiting due to KeyboardInterrupt...")
+finally:
+    print("Closing socket...")
+    if sock:
+        sock.close()
+    # Ensure listener thread has finished if it hasn't due to error
+    if listener_thread.is_alive():
+        print("Waiting for listener thread to join...")
+        # listener_thread.join(timeout=1) # sock.recv might be blocking
+    print("Client shut down.")

--- a/blue_server.py
+++ b/blue_server.py
@@ -1,38 +1,97 @@
 import bluetooth
 from datetime import datetime
 import threading
+import sys # For sys.exit()
 
-server_sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-server_sock.bind(("", bluetooth.PORT_ANY))
-server_sock.listen(1)
-port = server_sock.getsockname()[1]
+def start_bluetooth_server():
+    server_sock = None
+    client_sock = None
+    listener_thread = None
 
-bluetooth.advertise_service(server_sock, "BluetoothChatService",
-                            service_classes=[bluetooth.SERIAL_PORT_CLASS],
-                            profiles=[bluetooth.SERIAL_PORT_PROFILE])
-print("[Bluetooth] Waiting for connection on RFCOMM channel", port)
+    try:
+        server_sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
+        server_sock.bind(("", bluetooth.PORT_ANY))
+        server_sock.listen(1)
+        port = server_sock.getsockname()[1]
 
-client_sock, client_info = server_sock.accept()
-print("[Bluetooth] Accepted connection from", client_info)
+        bluetooth.advertise_service(server_sock, "BluetoothChatService",
+                                    service_id = bluetooth.SERIAL_PORT_CLASS, # Using common UUID
+                                    service_classes=[bluetooth.SERIAL_PORT_CLASS], # String UUID
+                                    profiles=[bluetooth.SERIAL_PORT_PROFILE]) # String UUID
+        print(f"[Bluetooth] Waiting for connection on RFCOMM channel {port}")
+        print("Ensure your device is discoverable and paired if necessary.")
 
-username = input("Enter your username: ")
+        try:
+            client_sock, client_info = server_sock.accept()
+            print(f"[Bluetooth] Accepted connection from {client_info}")
+        except bluetooth.btcommon.BluetoothError as e:
+            print(f"Bluetooth error during accept: {e}. Server may need to be restarted.")
+            return # Exit function if accept fails
 
-def listen():
-    while True:
-        data = client_sock.recv(1024)
-        if not data:
-            break
-        print("\n" + data.decode() + "\n> ", end="")
+        username = input("Enter your username: ")
+        print("Connected. Type /exit to quit or /clear to clear screen.")
 
-threading.Thread(target=listen, daemon=True).start()
+        def listen_fn(sock):
+            try:
+                while True:
+                    data = sock.recv(1024)
+                    if not data:
+                        print("\nClient disconnected.\n> ", end="")
+                        break
+                    print("\n" + data.decode() + "\n> ", end="")
+            except bluetooth.btcommon.BluetoothError as e:
+                print(f"\nBluetooth error during receive: {e}. Client disconnected.\n> ", end="")
+            except Exception as e:
+                print(f"\nError during receive: {e}. Client disconnected.\n> ", end="")
+            finally:
+                print("Listener thread finished.")
+                # Potentially signal main thread or close client_sock here if appropriate
+                # For now, main loop will handle client_sock closure on exit/error
 
-while True:
-    msg = input("> ")
-    if msg == "/exit":
-        break
-    timestamp = datetime.now().strftime('%H:%M')
-    full_message = f"[{timestamp}] {username}: {msg}"
-    client_sock.send(full_message.encode())
+        listener_thread = threading.Thread(target=listen_fn, args=(client_sock,), daemon=True)
+        listener_thread.start()
 
-client_sock.close()
-server_sock.close()
+        while True:
+            msg = input("> ")
+            if msg == "/exit":
+                break
+            elif msg == "/whoami":
+                print(f"You are {username}")
+                continue
+            elif msg == "/clear":
+                print("\033c", end="") # Basic clear
+                continue
+
+            timestamp = datetime.now().strftime('%H:%M')
+            full_message = f"[{timestamp}] {username}: {msg}"
+            try:
+                client_sock.send(full_message.encode())
+            except bluetooth.btcommon.BluetoothError as e:
+                print(f"Bluetooth error during send: {e}. Message may not have been sent.")
+                # If send fails, client might be disconnected. Listener should pick this up.
+                # Consider breaking here if send errors are critical
+            except Exception as e:
+                print(f"Error during send: {e}. Message may not have been sent.")
+
+
+    except bluetooth.btcommon.BluetoothError as e:
+        print(f"A critical Bluetooth error occurred: {e}")
+        print("Please ensure Bluetooth is enabled and drivers are correctly installed.")
+    except KeyboardInterrupt:
+        print("\nServer shutting down due to KeyboardInterrupt...")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+    finally:
+        print("Closing sockets...")
+        if client_sock:
+            client_sock.close()
+        if server_sock:
+            server_sock.close()
+        # Ensure listener thread has finished
+        if listener_thread and listener_thread.is_alive():
+            print("Waiting for listener thread to join...")
+            # listener_thread.join(timeout=1) # client_sock.recv might be blocking
+        print("Server shut down.")
+
+if __name__ == "__main__":
+    start_bluetooth_server()

--- a/blue_utils.py
+++ b/blue_utils.py
@@ -2,17 +2,59 @@ import bluetooth
 
 def discover_and_connect_bluetooth():
     print("Searching for nearby Bluetooth devices...")
-    devices = bluetooth.discover_devices(duration=8, lookup_names=True)
+    try:
+        devices = bluetooth.discover_devices(duration=8, lookup_names=True, flush_cache=True, lookup_class=False)
+    except bluetooth.btcommon.BluetoothError as e:
+        print(f"Bluetooth error during device discovery: {e}")
+        return None
+
     if not devices:
         print("No devices found.")
         return None
 
+    print("Found devices:")
     for i, (addr, name) in enumerate(devices):
-        print(f"{i+1}. {name} - {addr}")
+        print(f"  {i+1}. {name} ({addr})")
 
-    choice = int(input("Select device number to connect: ")) - 1
-    addr = devices[choice][0]
-    port = 1
+    while True:
+        try:
+            choice = input("Select device number to connect (or '0' to rescan): ")
+            if choice == '0':
+                return discover_and_connect_bluetooth() # Recursive call to rescan
+            choice_idx = int(choice) - 1
+            if 0 <= choice_idx < len(devices):
+                addr, name = devices[choice_idx]
+                break
+            else:
+                print("Invalid selection. Please try again.")
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+
+    print(f"Searching for BluetoothChatService on {name} ({addr})...")
+    try:
+        services = bluetooth.find_service(address=addr, name="BluetoothChatService")
+    except bluetooth.btcommon.BluetoothError as e:
+        print(f"Bluetooth error during service discovery: {e}")
+        return None
+
+    if not services:
+        print("BluetoothChatService not found on the selected device.")
+        print("Ensure the server is running and advertising the service, and that devices are paired.")
+        return None
+
+    service_info = services[0]
+    port = service_info["port"]
+    host = service_info["host"] # This is addr
+
+    print(f"Connecting to {name} ({host}) on port {port}...")
     sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-    sock.connect((addr, port))
-    return sock
+    try:
+        sock.connect((host, port))
+        print("Successfully connected!")
+        return sock
+    except bluetooth.btcommon.BluetoothError as e:
+        print(f"Bluetooth error during connection: {e}")
+        return None
+    except Exception as e:
+        print(f"An unexpected error occurred during connection: {e}")
+        return None

--- a/client.py
+++ b/client.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 
 username = input("Enter your username: ")
+server_ip = input("Enter the server's IP address (e.g., 192.168.1.5): ")
 
 def on_message(ws, message):
     print("\n" + message + "\n> ", end="")
@@ -33,7 +34,7 @@ def on_open(ws):
 
 if __name__ == "__main__":
     websocket.enableTrace(False)
-    ws = websocket.WebSocketApp("ws://localhost:5000/socket.io/?EIO=4&transport=websocket",
+    ws = websocket.WebSocketApp(f"ws://{server_ip}:5000/socket.io/?EIO=4&transport=websocket",
                                 on_open=on_open,
                                 on_message=on_message,
                                 on_error=on_error,

--- a/server.py
+++ b/server.py
@@ -21,3 +21,10 @@ def handle_message(data):
 
 if __name__ == '__main__':
     socketio.run(app, host='0.0.0.0', port=5000)
+    print("\nServer is running on 0.0.0.0:5000.")
+    print("Clients on your local network can connect to you using your machine's local IP address.")
+    print("To find your IP address:")
+    print("  - On Windows: Open Command Prompt and type 'ipconfig'")
+    print("  - On Linux: Open a terminal and type 'ip addr' or 'hostname -I'")
+    print("  - On macOS: Open Terminal and type 'ifconfig'")
+    print("Share this IP address with other users.\n")


### PR DESCRIPTION
This commit introduces several improvements to the local chat application:

Network Chat (Wi-Fi/Ethernet):
- `client.py` (terminal client) now prompts for the server's IP address, allowing connections to servers on the local network.
- `server.py` now prints instructions on startup to help you find your local IP address.
- `README.md` updated with clear instructions for finding the server IP and connecting clients.

Bluetooth Chat:
- Fixed a critical bug in `blue_client.py` and `blue_utils.py` where a hardcoded port was used. The client now performs Bluetooth service discovery (SDP) to find the correct port for "BluetoothChatService" advertised by `blue_server.py`.
- Added robust error handling (try-except blocks for Bluetooth operations) to `blue_server.py`, `blue_client.py`, and `blue_utils.py` to manage disconnections and other Bluetooth issues gracefully.
- `blue_client.py` now utilizes the `discover_and_connect_bluetooth` function from `blue_utils.py`.
- Added `/whoami` and `/clear` commands to the Bluetooth server and client for feature parity with the WebSocket client.

README & General:
- Significantly refactored and consolidated `README.md` for improved clarity, structure, and completeness.
- Provides detailed setup and usage instructions for both Network (Wi-Fi) chat (Web UI and terminal client) and Bluetooth chat.
- Includes notes on dependencies (PyBluez and system-level Bluetooth packages) and troubleshooting for Bluetooth.

These changes make the terminal-based chat more usable over a local network and improve the reliability and documentation of the Bluetooth chat feature.